### PR TITLE
Upgrade moment.js module

### DIFF
--- a/azure-deployment/EtheriumConsortium/scripts/etheradmin/package.json
+++ b/azure-deployment/EtheriumConsortium/scripts/etheradmin/package.json
@@ -13,7 +13,7 @@
     "express": "^4.15.2",
     "express-handlebars": "~3.0.0",
     "express-session": "^1.15.2",
-    "moment": "~2.17.1",
+    "moment": "~2.19.3",
     "promise": "~7.1.1",
     "web3": "~0.19.1"
   }


### PR DESCRIPTION
Upgrade moment.js module from 2.17.1 to 2.19.3, in order to remove security vulnerability